### PR TITLE
Added setting to allow non-GM players to modify initiative.

### DIFF
--- a/Combat.js
+++ b/Combat.js
@@ -1,6 +1,6 @@
 class FurnaceCombatQoL {
     static renderCombatTracker(tracker, html, data) {
-        if (!game.user.isGM) return;
+        if (game.user.role < parseInt(game.settings.get("initiative-double-click","player-access")) ) return;
         html.find(".token-initiative").off("dblclick").on("dblclick", FurnaceCombatQoL._onInitiativeDblClick)
         for (let combatant of html.find("#combat-tracker li.combatant")) {
             if (combatant.classList.contains("active"))
@@ -15,6 +15,7 @@ class FurnaceCombatQoL {
         let cid = html.data("combatant-id")
         let initiative = html.find(".token-initiative")
         let combatant = game.combat.combatants.get(cid)
+        if (!combatant.isOwner) return;
         let input = $(`<input class="initiative" style="width: 90%" value="${combatant.initiative}"/>`)
         initiative.off("dblclick")
         initiative.empty().append(input)
@@ -27,3 +28,20 @@ class FurnaceCombatQoL {
 }
 
 Hooks.on('renderCombatTracker', FurnaceCombatQoL.renderCombatTracker)
+Hooks.once("init", () => {
+    game.settings.register("initiative-double-click", "player-access", {
+        name: game.i18n.localize("initiative-double-click.settings.player-access.name"),
+        hint: game.i18n.localize("initiative-double-click.settings.player-access.hint"),
+        scope: "world",
+        config: true,
+        type: String,
+        default: "4",
+        choices: {
+          "0": "initiative-double-click.settings.player-access.roles.none",
+          "1": "initiative-double-click.settings.player-access.roles.player",
+          "2": "initiative-double-click.settings.player-access.roles.trusted",
+          "3": "initiative-double-click.settings.player-access.roles.assistant",
+          "4": "initiative-double-click.settings.player-access.roles.gamemaster"
+        }
+    });
+});

--- a/langs/en.json
+++ b/langs/en.json
@@ -1,0 +1,10 @@
+{
+    "initiative-double-click.settings.player-access.name" : "Minimum Permission Level",
+    "initiative-double-click.settings.player-access.hint" : "Allows users with at least this permission level to modify initiative of owned tokens.",
+
+    "initiative-double-click.settings.player-access.roles.none" : "None",
+    "initiative-double-click.settings.player-access.roles.player" : "Player",
+    "initiative-double-click.settings.player-access.roles.trusted" : "Trusted Player",
+    "initiative-double-click.settings.player-access.roles.assistant" : "Assistant GM",
+    "initiative-double-click.settings.player-access.roles.gamemaster" : "Game Master"
+}

--- a/module.json
+++ b/module.json
@@ -8,13 +8,19 @@
   "flags": {},
   "version": "2.6.0",
   "minimumCoreVersion": "0.8.4",
-  "compatibleCoreVersion": "0.8.6",
+  "compatibleCoreVersion": "0.8.8",
   "scripts": [
     "Combat.js"
   ],
   "esmodules": [],
   "styles": [],
-  "languages": [],
+  "languages": [
+    {
+      "lang": "en",
+      "name": "English",
+      "path": "langs/en.json"
+    }
+  ],
   "packs": [],
   "system": [],
   "dependencies": [],


### PR DESCRIPTION
- Added new restriction to only allow the initiative of owned combatants to be modified.
- Changed restriction for modifying initiative from only-GM to being  based on the setting and the role of the user.
- Added a setting to allow the GM to decide this permission level.
- Now with user-facing settings, added folder for localization, as well as support for English.
- Tested on 0.8.8 and changed compatible version accordingly.