### PR TITLE
change call to update combatant initiative value to be compatible with v9.

### DIFF
--- a/Combat.js
+++ b/Combat.js
@@ -20,7 +20,7 @@ class FurnaceCombatQoL {
         initiative.off("dblclick")
         initiative.empty().append(input)
         input.focus().select()
-        input.on('change', ev => game.combat.updateCombatant({ _id: cid, initiative: input.val() }))
+        input.on('change', ev => game.combat.setInitiative(cid, input.val()));
         input.on('focusout', ev => game.combats.render())
 
 

--- a/module.json
+++ b/module.json
@@ -8,7 +8,7 @@
   "flags": {},
   "version": "2.6.0",
   "minimumCoreVersion": "0.8.4",
-  "compatibleCoreVersion": "0.8.8",
+  "compatibleCoreVersion": "9",
   "scripts": [
     "Combat.js"
   ],


### PR DESCRIPTION
This works in v9. I half tested it in my stable v0.8.9 server via the console and it appears that the same API that I'm using works there as well, so I left the module manifest min version to 0.8.